### PR TITLE
enabling openmpi in centos builds; enabling mpi across all configs

### DIFF
--- a/containers/singularity/sstcore-11.0.0-centos7.def
+++ b/containers/singularity/sstcore-11.0.0-centos7.def
@@ -33,7 +33,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               mpich \
+               openmpi \
                python3 \
                python3-devel \
                python3-pip \
@@ -64,8 +64,8 @@ Include: yum
 
     cd /opt/SST/11.0.0/src
     tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
-    cd sstcore-11.0.0; ./configure --disable-mpi --prefix=/opt/SST/11.0.0; time make -j all; make install
- 
+    cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; time make -j all; make install
+
 
 %help
     SST 11.0.0-Centos 7: Creates a basic SST Core image with the necessary software dependencies

--- a/containers/singularity/sstcore-11.0.0-centos7.def
+++ b/containers/singularity/sstcore-11.0.0-centos7.def
@@ -2,10 +2,11 @@ Bootstrap: yum
 OSVersion: 7
 MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
 Include: yum
- 
+
 
 %setup
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/11.0.0/src
+    mkdir -p ${SINGULARITY_ROOTFS}/opt/OpenMPI/4.0.5/src
 
 
 %files
@@ -13,7 +14,7 @@ Include: yum
 
 
 %environment
-    PATH=$PATH:/opt/SST/11.0.0/bin
+    PATH=$PATH:/opt/SST/11.0.0/bin:/opt/OpenMPI/4.0.5/bin
     LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 
 
@@ -33,7 +34,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               openmpi \
+               wget \
                python3 \
                python3-devel \
                python3-pip \
@@ -62,6 +63,13 @@ Include: yum
     source scl_source enable devtoolset-8 || true
     PATH=/opt/rh/devtoolset-8/root/bin:$PATH
 
+    cd /opt/OpenMPI/4.0.5/src
+    wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
+    tar --no-same-owner xzvf openmpi-4.0.5.tar.gz
+    cd openmpi-4.0.5
+    ./configure --prefix=/opt/OpenMPI/4.0.5
+    make -j; make install
+    export PATH=/opt/OpenMPI/4.0.5/bin:$PATH
     cd /opt/SST/11.0.0/src
     tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
     cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; time make -j all; make install

--- a/containers/singularity/sstcore-11.0.0-centos8.def
+++ b/containers/singularity/sstcore-11.0.0-centos8.def
@@ -1,11 +1,12 @@
 Bootstrap: yum
-OSVersion: 7
+OSVersion: 8
 MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
 Include: yum
- 
+
 
 %setup
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/11.0.0/src
+    mkdir -p ${SINGULARITY_ROOTFS}/opt/OpenMPI/4.0.5/src
 
 
 %files
@@ -13,7 +14,7 @@ Include: yum
 
 
 %environment
-    PATH=$PATH:/opt/SST/11.0.0/bin
+    PATH=$PATH:/opt/SST/11.0.0/bin:/opt/OpenMPI/4.0.5/bin
     LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 #    The two lines below were necessary to avoid a SELinux alert, but perhaps a better way to avoid?
 #    ausearch -c 'systemd-tmpfile' --raw | audit2allow -M my-systemdtmpfile
@@ -36,7 +37,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               openmpi \
+               wget \
                python3 \
                python3-devel \
                python3-pip \
@@ -65,10 +66,17 @@ Include: yum
     source scl_source enable devtoolset-8 || true
     PATH=/opt/rh/devtoolset-8/root/bin:$PATH
 
+    cd /opt/OpenMPI/4.0.5/src
+    wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
+    tar --no-same-owner -xzvf openmpi-4.0.5.tar.gz
+    cd openmpi-4.0.5
+    ./configure --prefix=/opt/OpenMPI/4.0.5
+    make -j; make install
+    export PATH=/opt/OpenMPI/4.0.5/bin:$PATH
     cd /opt/SST/11.0.0/src
     tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
     cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; time make -j all; make install
- 
+
 
 %help
     SST 11.0.0-Centos 8: Creates a basic SST Core image with the necessary software dependencies

--- a/containers/singularity/sstcore-11.0.0-centos8.def
+++ b/containers/singularity/sstcore-11.0.0-centos8.def
@@ -36,7 +36,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               mpich \
+               openmpi \
                python3 \
                python3-devel \
                python3-pip \
@@ -67,7 +67,7 @@ Include: yum
 
     cd /opt/SST/11.0.0/src
     tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
-    cd sstcore-11.0.0; ./configure --disable-mpi --prefix=/opt/SST/11.0.0; time make -j all; make install
+    cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; time make -j all; make install
  
 
 %help

--- a/containers/singularity/sstcore-11.0.0-ubuntu-18.04.def
+++ b/containers/singularity/sstcore-11.0.0-ubuntu-18.04.def
@@ -52,7 +52,7 @@ Include: software-properties-common
 
   cd /opt/SST/11.0.0/src
   tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
-  cd sstcore-11.0.0; ./configure --disable-mpi --prefix=/opt/SST/11.0.0; make -j all; make install
+  cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; make -j all; make install
 
   NOW=`date`
   echo "export NOW=\"${NOW}\"" >> $SINGULARITY_ENVIRONMENT

--- a/containers/singularity/sstcore-11.0.0-ubuntu-20.04.def
+++ b/containers/singularity/sstcore-11.0.0-ubuntu-20.04.def
@@ -52,7 +52,7 @@ Include: software-properties-common dbus-user-session
 
   cd /opt/SST/11.0.0/src
   tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
-  cd sstcore-11.0.0; ./configure --disable-mpi --prefix=/opt/SST/11.0.0; make -j all; make install
+  cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; make -j all; make install
 
   NOW=`date`
   echo "export NOW=\"${NOW}\"" >> $SINGULARITY_ENVIRONMENT

--- a/containers/singularity/sstcore-MASTER-centos7.def
+++ b/containers/singularity/sstcore-MASTER-centos7.def
@@ -32,7 +32,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               mpich \
+               openmpi \
                python3 \
                python3-devel \
                python3-pip \
@@ -67,7 +67,7 @@ Include: yum
 
     cd /opt/SST/MASTER/src
     git clone https://github.com/sstsimulator/sst-core.git
-    cd sst-core; ./autogen.sh; ./configure --disable-mpi --prefix=/opt/SST/MASTER; time make -j all; make install
+    cd sst-core; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER; time make -j all; make install
 
 
 %help

--- a/containers/singularity/sstcore-MASTER-centos7.def
+++ b/containers/singularity/sstcore-MASTER-centos7.def
@@ -6,13 +6,13 @@ Include: yum
 
 %setup
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/MASTER/src
-
+    mkdir -p ${SINGULARITY_ROOTFS}/opt/OpenMPI/4.0.5/src
 
 %files
 
 
 %environment
-    PATH=$PATH:/opt/SST/MASTER/bin
+    PATH=$PATH:/opt/SST/MASTER/bin:/opt/OpenMPI/4.0.5/bin
     LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 
 
@@ -32,7 +32,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               openmpi \
+               wget \
                python3 \
                python3-devel \
                python3-pip \
@@ -65,6 +65,13 @@ Include: yum
     source scl_source enable devtoolset-8 || true
     PATH=/opt/rh/devtoolset-8/root/bin:$PATH
 
+    cd /opt/OpenMPI/4.0.5/src
+    wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
+    tar --no-same-owner xzvf openmpi-4.0.5.tar.gz
+    cd openmpi-4.0.5
+    ./configure --prefix=/opt/OpenMPI/4.0.5
+    make -j; make install
+    export PATH=/opt/OpenMPI/4.0.5/bin:$PATH
     cd /opt/SST/MASTER/src
     git clone https://github.com/sstsimulator/sst-core.git
     cd sst-core; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER; time make -j all; make install

--- a/containers/singularity/sstcore-MASTER-centos8.def
+++ b/containers/singularity/sstcore-MASTER-centos8.def
@@ -1,18 +1,19 @@
 Bootstrap: yum
-OSVersion: 7
+OSVersion: 8
 MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
 Include: yum
 
 
 %setup
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/MASTER/src
+    mkdir -p ${SINGULARITY_ROOTFS}/opt/OpenMPI/4.0.5/src
 
 
 %files
 
 
 %environment
-    PATH=$PATH:/opt/SST/MASTER/bin
+    PATH=$PATH:/opt/SST/MASTER/bin:/opt/OpenMPI/4.0.5/bin
     LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 #    The two lines below were necessary to avoid a SELinux alert, but perhaps a better way to avoid?
 #    ausearch -c 'systemd-tmpfile' --raw | audit2allow -M my-systemdtmpfile
@@ -35,7 +36,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               openmpi \
+               wget \
                python3 \
                python3-devel \
                python3-pip \
@@ -67,6 +68,13 @@ Include: yum
     source scl_source enable devtoolset-8 || true
     PATH=/opt/rh/devtoolset-8/root/bin:$PATH
 
+    cd /opt/OpenMPI/4.0.5/src
+    wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
+    tar --no-same-owner -xzvf openmpi-4.0.5.tar.gz
+    cd openmpi-4.0.5
+    ./configure --prefix=/opt/OpenMPI/4.0.5
+    make -j; make install
+    export PATH=/opt/OpenMPI/4.0.5/bin:$PATH
     cd /opt/SST/MASTER/src
     git clone https://github.com/sstsimulator/sst-core.git
     cd sst-core; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER; time make -j all; make install

--- a/containers/singularity/sstcore-MASTER-centos8.def
+++ b/containers/singularity/sstcore-MASTER-centos8.def
@@ -35,7 +35,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               mpich \
+               openmpi \
                python3 \
                python3-devel \
                python3-pip \
@@ -69,7 +69,7 @@ Include: yum
 
     cd /opt/SST/MASTER/src
     git clone https://github.com/sstsimulator/sst-core.git
-    cd sst-core; ./autogen.sh; ./configure --disable-mpi --prefix=/opt/SST/MASTER; time make -j all; make install
+    cd sst-core; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER; time make -j all; make install
 
 
 %help

--- a/containers/singularity/sstcore-MASTER-ubuntu-18.04.def
+++ b/containers/singularity/sstcore-MASTER-ubuntu-18.04.def
@@ -54,7 +54,7 @@ Include: software-properties-common
 
   cd /opt/SST/MASTER/src
   git clone https://github.com/sstsimulator/sst-core.git
-  cd sst-core; ./autogen.sh; ./configure --disable-mpi --prefix=/opt/SST/MASTER; make -j all; make install
+  cd sst-core; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER; make -j all; make install
 
   NOW=`date`
   echo "export NOW=\"${NOW}\"" >> $SINGULARITY_ENVIRONMENT

--- a/containers/singularity/sstcore-MASTER-ubuntu-20.04.def
+++ b/containers/singularity/sstcore-MASTER-ubuntu-20.04.def
@@ -54,7 +54,7 @@ Include: software-properties-common dbus-user-session
 
   cd /opt/SST/MASTER/src
   git clone https://github.com/sstsimulator/sst-core.git
-  cd sst-core; ./autogen.sh; ./configure --disable-mpi --prefix=/opt/SST/MASTER; make -j all; make install
+  cd sst-core; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER; make -j all; make install
 
   NOW=`date`
   echo "export NOW=\"${NOW}\"" >> $SINGULARITY_ENVIRONMENT

--- a/containers/singularity/sstpackage-11.0.0-centos7.def
+++ b/containers/singularity/sstpackage-11.0.0-centos7.def
@@ -7,6 +7,7 @@ Include: yum
 %setup
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/11.0.0/src
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/11.0.0/elements
+    mkdir -p ${SINGULARITY_ROOTFS}/opt/OpenMPI/4.0.5/src
 
 
 %files
@@ -15,7 +16,7 @@ Include: yum
 
 
 %environment
-    PATH=$PATH:/opt/SST/11.0.0/bin
+    PATH=$PATH:/opt/SST/11.0.0/bin:/opt/OpenMPI/4.0.5/bin
     LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 
 
@@ -35,7 +36,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               openmpi \
+               wget \
                python3 \
                python3-devel \
                python3-pip \
@@ -64,10 +65,18 @@ Include: yum
     source scl_source enable devtoolset-8 || true
     PATH=/opt/rh/devtoolset-8/root/bin:$PATH
 
+    cd /opt/OpenMPI/4.0.5/src
+    wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
+    tar --no-same-owner xzvf openmpi-4.0.5.tar.gz
+    cd openmpi-4.0.5
+    ./configure --prefix=/opt/OpenMPI/4.0.5
+    make -j; make install
+    export PATH=/opt/OpenMPI/4.0.5/bin:$PATH
+
     cd /opt/SST/11.0.0/src
     tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
     cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; time make -j all; make install
- 
+
     cd /opt/SST/11.0.0/src
     tar --no-same-owner -xvzf sstelements-11.0.0.tar.gz
     cd sst-elements-library-11.0.0; ./configure --prefix=/opt/SST/11.0.0/elements -with-sst-core=/opt/SST/11.0.0; time make -j all; make install

--- a/containers/singularity/sstpackage-11.0.0-centos7.def
+++ b/containers/singularity/sstpackage-11.0.0-centos7.def
@@ -35,7 +35,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               mpich \
+               openmpi \
                python3 \
                python3-devel \
                python3-pip \
@@ -66,7 +66,7 @@ Include: yum
 
     cd /opt/SST/11.0.0/src
     tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
-    cd sstcore-11.0.0; ./configure --disable-mpi --prefix=/opt/SST/11.0.0; time make -j all; make install
+    cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; time make -j all; make install
  
     cd /opt/SST/11.0.0/src
     tar --no-same-owner -xvzf sstelements-11.0.0.tar.gz

--- a/containers/singularity/sstpackage-11.0.0-centos8.def
+++ b/containers/singularity/sstpackage-11.0.0-centos8.def
@@ -37,6 +37,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
+               openmpi \
                mpich \
                python3 \
                python3-devel \
@@ -68,7 +69,7 @@ Include: yum
 
     cd /opt/SST/11.0.0/src
     tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
-    cd sstcore-11.0.0; ./configure --disable-mpi --prefix=/opt/SST/11.0.0; time make -j all; make install
+    cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; time make -j all; make install
 
     cd /opt/SST/11.0.0/src
     tar --no-same-owner -xvzf sstelements-11.0.0.tar.gz

--- a/containers/singularity/sstpackage-11.0.0-centos8.def
+++ b/containers/singularity/sstpackage-11.0.0-centos8.def
@@ -1,5 +1,5 @@
 Bootstrap: yum
-OSVersion: 7
+OSVersion: 8
 MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
 Include: yum
 
@@ -7,6 +7,7 @@ Include: yum
 %setup
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/11.0.0/src
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/11.0.0/elements
+    mkdir -p ${SINGULARITY_ROOTFS}/opt/OpenMPI/4.0.5/src
 
 
 %files
@@ -17,7 +18,7 @@ Include: yum
 #    semodule -X 300 -i my-systemdtmpfile.pp
 
 %environment
-    PATH=$PATH:/opt/SST/11.0.0/bin
+    PATH=$PATH:/opt/SST/11.0.0/bin:/opt/OpenMPI/4.0.5/bin
     LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 
 
@@ -37,8 +38,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               openmpi \
-               mpich \
+               wget \
                python3 \
                python3-devel \
                python3-pip \
@@ -71,6 +71,13 @@ Include: yum
     tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
     cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; time make -j all; make install
 
+    cd /opt/OpenMPI/4.0.5/src
+    wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
+    tar --no-same-owner -xzvf openmpi-4.0.5.tar.gz
+    cd openmpi-4.0.5
+    ./configure --prefix=/opt/OpenMPI/4.0.5
+    make -j; make install
+    export PATH=/opt/OpenMPI/4.0.5/bin:$PATH
     cd /opt/SST/11.0.0/src
     tar --no-same-owner -xvzf sstelements-11.0.0.tar.gz
     cd sst-elements-library-11.0.0; ./configure --prefix=/opt/SST/11.0.0/elements -with-sst-core=/opt/SST/11.0.0; time make -j all; make install

--- a/containers/singularity/sstpackage-11.0.0-ubuntu-18.04.def
+++ b/containers/singularity/sstpackage-11.0.0-ubuntu-18.04.def
@@ -54,7 +54,7 @@ Include: software-properties-common
 
   cd /opt/SST/11.0.0/src
   tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
-  cd sstcore-11.0.0; ./configure --disable-mpi --prefix=/opt/SST/11.0.0; make -j all; make install
+  cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; make -j all; make install
 
   cd /opt/SST/11.0.0/src
   tar --no-same-owner -xvzf sstelements-11.0.0.tar.gz

--- a/containers/singularity/sstpackage-11.0.0-ubuntu-20.04.def
+++ b/containers/singularity/sstpackage-11.0.0-ubuntu-20.04.def
@@ -54,7 +54,7 @@ Include: software-properties-common dbus-user-session
 
   cd /opt/SST/11.0.0/src
   tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
-  cd sstcore-11.0.0; ./configure --disable-mpi --prefix=/opt/SST/11.0.0; make -j all; make install
+  cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; make -j all; make install
 
   cd /opt/SST/11.0.0/src
   tar --no-same-owner -xvzf sstelements-11.0.0.tar.gz

--- a/containers/singularity/sstpackage-MASTER-centos7.def
+++ b/containers/singularity/sstpackage-MASTER-centos7.def
@@ -32,7 +32,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               mpich \
+               openmpi \
                python3 \
                python3-devel \
                python3-pip \
@@ -68,7 +68,7 @@ Include: yum
     cd /opt/SST/MASTER/src
     git clone https://github.com/sstsimulator/sst-core.git
     git clone https://github.com/sstsimulator/sst-elements.git
-    cd sst-core; ./autogen.sh; ./configure --disable-mpi --prefix=/opt/SST/MASTER; time make -j all; make install
+    cd sst-core; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER; time make -j all; make install
     cd ../sst-elements; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER/elements -with-sst-core=/opt/SST/MASTER; make -j all; make install
 
 

--- a/containers/singularity/sstpackage-MASTER-centos7.def
+++ b/containers/singularity/sstpackage-MASTER-centos7.def
@@ -7,12 +7,13 @@ Include: yum
 %setup
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/MASTER/src
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/MASTER/elements
+    mkdir -p ${SINGULARITY_ROOTFS}/opt/OpenMPI/4.0.5/src
 
 %files
 
 
 %environment
-    PATH=$PATH:/opt/SST/MASTER/bin
+    PATH=$PATH:/opt/SST/MASTER/bin:/opt/OpenMPI/4.0.5/bin
     LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 
 
@@ -32,7 +33,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               openmpi \
+               wget \
                python3 \
                python3-devel \
                python3-pip \
@@ -64,6 +65,14 @@ Include: yum
     set -e
     source scl_source enable devtoolset-8 || true
     PATH=/opt/rh/devtoolset-8/root/bin:$PATH
+
+    cd /opt/OpenMPI/4.0.5/src
+    wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
+    tar --no-same-owner xzvf openmpi-4.0.5.tar.gz
+    cd openmpi-4.0.5
+    ./configure --prefix=/opt/OpenMPI/4.0.5
+    make -j; make install
+    export PATH=/opt/OpenMPI/4.0.5/bin:$PATH
 
     cd /opt/SST/MASTER/src
     git clone https://github.com/sstsimulator/sst-core.git

--- a/containers/singularity/sstpackage-MASTER-centos8.def
+++ b/containers/singularity/sstpackage-MASTER-centos8.def
@@ -35,7 +35,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               mpich \
+               openmpi \
                python3 \
                python3-devel \
                python3-pip \
@@ -71,7 +71,7 @@ Include: yum
     cd /opt/SST/MASTER/src
     git clone https://github.com/sstsimulator/sst-core.git
     git clone https://github.com/sstsimulator/sst-elements.git
-    cd sst-core; ./autogen.sh; ./configure --disable-mpi --prefix=/opt/SST/MASTER; time make -j all; make install
+    cd sst-core; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER; time make -j all; make install
     cd ../sst-elements; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER/elements -with-sst-core=/opt/SST/MASTER; make -j all; make install
 
 

--- a/containers/singularity/sstpackage-MASTER-centos8.def
+++ b/containers/singularity/sstpackage-MASTER-centos8.def
@@ -1,5 +1,5 @@
 Bootstrap: yum
-OSVersion: 7
+OSVersion: 8
 MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
 Include: yum
 
@@ -7,12 +7,13 @@ Include: yum
 %setup
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/MASTER/src
     mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/MASTER/elements
+    mkdir -p ${SINGULARITY_ROOTFS}/opt/SST/MASTER/src
 
 %files
 
 
 %environment
-    PATH=$PATH:/opt/SST/MASTER/bin
+    PATH=$PATH:/opt/SST/MASTER/bin:/opt/OpenMPI/4.0.5/bin
     LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 #    The two lines below were necessary to avoid a SELinux alert, but perhaps a better way to avoid?
 #    ausearch -c 'systemd-tmpfile' --raw | audit2allow -M my-systemdtmpfile
@@ -35,7 +36,7 @@ Include: yum
                doxygen \
                graphviz \
                time \
-               openmpi \
+               wget \
                python3 \
                python3-devel \
                python3-pip \
@@ -68,6 +69,13 @@ Include: yum
     source scl_source enable devtoolset-8 || true
     PATH=/opt/rh/devtoolset-8/root/bin:$PATH
 
+    cd /opt/OpenMPI/4.0.5/src
+    wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
+    tar --no-same-owner -xzvf openmpi-4.0.5.tar.gz
+    cd openmpi-4.0.5
+    ./configure --prefix=/opt/OpenMPI/4.0.5
+    make -j; make install
+    export PATH=/opt/OpenMPI/4.0.5/bin:$PATH
     cd /opt/SST/MASTER/src
     git clone https://github.com/sstsimulator/sst-core.git
     git clone https://github.com/sstsimulator/sst-elements.git

--- a/containers/singularity/sstpackage-MASTER-ubuntu-18.04.def
+++ b/containers/singularity/sstpackage-MASTER-ubuntu-18.04.def
@@ -56,7 +56,7 @@ Include: software-properties-common
   cd /opt/SST/MASTER/src
   git clone https://github.com/sstsimulator/sst-core.git
   git clone https://github.com/sstsimulator/sst-elements.git
-  cd sst-core; ./autogen.sh; ./configure --disable-mpi --prefix=/opt/SST/MASTER; make -j all; make install
+  cd sst-core; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER; make -j all; make install
   cd ../sst-elements; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER/elements -with-sst-core=/opt/SST/MASTER; make -j all; make install
 
   NOW=`date`

--- a/containers/singularity/sstpackage-MASTER-ubuntu-20.04.def
+++ b/containers/singularity/sstpackage-MASTER-ubuntu-20.04.def
@@ -56,7 +56,7 @@ Include: software-properties-common dbus-user-session
   cd /opt/SST/MASTER/src
   git clone https://github.com/sstsimulator/sst-core.git
   git clone https://github.com/sstsimulator/sst-elements.git
-  cd sst-core; ./autogen.sh; ./configure --disable-mpi --prefix=/opt/SST/MASTER; make -j all; make install
+  cd sst-core; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER; make -j all; make install
   cd ../sst-elements; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER/elements -with-sst-core=/opt/SST/MASTER; make -j all; make install
 
   NOW=`date`


### PR DESCRIPTION
Enabling OpenMPI in CentOS builds; Deprecates MPICH; Enabling MPI across all configs; Fix for Issue #1 