### PR TITLE
Additional fixes to CentOS and Ubuntu containers for OpenMPI compatability

### DIFF
--- a/containers/singularity/sstcore-11.0.0-centos7.def
+++ b/containers/singularity/sstcore-11.0.0-centos7.def
@@ -65,7 +65,7 @@ Include: yum
 
     cd /opt/OpenMPI/4.0.5/src
     wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
-    tar --no-same-owner xzvf openmpi-4.0.5.tar.gz
+    tar --no-same-owner -xzvf openmpi-4.0.5.tar.gz
     cd openmpi-4.0.5
     ./configure --prefix=/opt/OpenMPI/4.0.5
     make -j; make install

--- a/containers/singularity/sstcore-11.0.0-centos8.def
+++ b/containers/singularity/sstcore-11.0.0-centos8.def
@@ -1,6 +1,6 @@
 Bootstrap: yum
-OSVersion: 8
-MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
+OSVersion: 7
+MirrorURL: http://mirror.centos.org/centos-8/8/BaseOS/x86_64/os/
 Include: yum
 
 

--- a/containers/singularity/sstcore-11.0.0-ubuntu-18.04.def
+++ b/containers/singularity/sstcore-11.0.0-ubuntu-18.04.def
@@ -50,6 +50,7 @@ Include: software-properties-common
     blessings \
     pygments
 
+  echo "btl_base_warn_component_unused = 0" >> /etc/openmpi/openmpi-mca-params.conf
   cd /opt/SST/11.0.0/src
   tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
   cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; make -j all; make install

--- a/containers/singularity/sstcore-MASTER-centos7.def
+++ b/containers/singularity/sstcore-MASTER-centos7.def
@@ -67,7 +67,7 @@ Include: yum
 
     cd /opt/OpenMPI/4.0.5/src
     wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
-    tar --no-same-owner xzvf openmpi-4.0.5.tar.gz
+    tar --no-same-owner -xzvf openmpi-4.0.5.tar.gz
     cd openmpi-4.0.5
     ./configure --prefix=/opt/OpenMPI/4.0.5
     make -j; make install

--- a/containers/singularity/sstcore-MASTER-centos8.def
+++ b/containers/singularity/sstcore-MASTER-centos8.def
@@ -1,6 +1,6 @@
 Bootstrap: yum
 OSVersion: 8
-MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
+MirrorURL: http://mirror.centos.org/centos-8/8/BaseOS/x86_64/os/
 Include: yum
 
 

--- a/containers/singularity/sstcore-MASTER-ubuntu-18.04.def
+++ b/containers/singularity/sstcore-MASTER-ubuntu-18.04.def
@@ -52,6 +52,7 @@ Include: software-properties-common
     blessings \
     pygments
 
+  echo "btl_base_warn_component_unused = 0" >> /etc/openmpi/openmpi-mca-params.conf
   cd /opt/SST/MASTER/src
   git clone https://github.com/sstsimulator/sst-core.git
   cd sst-core; ./autogen.sh; ./configure --prefix=/opt/SST/MASTER; make -j all; make install

--- a/containers/singularity/sstpackage-11.0.0-centos7.def
+++ b/containers/singularity/sstpackage-11.0.0-centos7.def
@@ -67,7 +67,7 @@ Include: yum
 
     cd /opt/OpenMPI/4.0.5/src
     wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
-    tar --no-same-owner xzvf openmpi-4.0.5.tar.gz
+    tar --no-same-owner -xzvf openmpi-4.0.5.tar.gz
     cd openmpi-4.0.5
     ./configure --prefix=/opt/OpenMPI/4.0.5
     make -j; make install

--- a/containers/singularity/sstpackage-11.0.0-centos8.def
+++ b/containers/singularity/sstpackage-11.0.0-centos8.def
@@ -1,6 +1,6 @@
 Bootstrap: yum
 OSVersion: 8
-MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
+MirrorURL: http://mirror.centos.org/centos-8/8/BaseOS/x86_64/os/
 Include: yum
 
 

--- a/containers/singularity/sstpackage-11.0.0-ubuntu-18.04.def
+++ b/containers/singularity/sstpackage-11.0.0-ubuntu-18.04.def
@@ -52,6 +52,7 @@ Include: software-properties-common
     blessings \
     pygments
 
+  echo "btl_base_warn_component_unused = 0" >> /etc/openmpi/openmpi-mca-params.conf
   cd /opt/SST/11.0.0/src
   tar --no-same-owner -xvzf sstcore-11.0.0.tar.gz
   cd sstcore-11.0.0; ./configure --prefix=/opt/SST/11.0.0; make -j all; make install

--- a/containers/singularity/sstpackage-MASTER-centos7.def
+++ b/containers/singularity/sstpackage-MASTER-centos7.def
@@ -68,7 +68,7 @@ Include: yum
 
     cd /opt/OpenMPI/4.0.5/src
     wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz
-    tar --no-same-owner xzvf openmpi-4.0.5.tar.gz
+    tar --no-same-owner -xzvf openmpi-4.0.5.tar.gz
     cd openmpi-4.0.5
     ./configure --prefix=/opt/OpenMPI/4.0.5
     make -j; make install

--- a/containers/singularity/sstpackage-MASTER-centos8.def
+++ b/containers/singularity/sstpackage-MASTER-centos8.def
@@ -1,6 +1,6 @@
 Bootstrap: yum
 OSVersion: 8
-MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
+MirrorURL: http://mirror.centos.org/centos-8/8/BaseOS/x86_64/os/
 Include: yum
 
 

--- a/containers/singularity/sstpackage-MASTER-ubuntu-18.04.def
+++ b/containers/singularity/sstpackage-MASTER-ubuntu-18.04.def
@@ -53,6 +53,7 @@ Include: software-properties-common
     blessings \
     pygments
 
+  echo "btl_base_warn_component_unused = 0" >> /etc/openmpi/openmpi-mca-params.conf
   cd /opt/SST/MASTER/src
   git clone https://github.com/sstsimulator/sst-core.git
   git clone https://github.com/sstsimulator/sst-elements.git


### PR DESCRIPTION
forces new upstream repos for Centos8 and forces BTL transfer layers for OpenMPI on ubuntu 18.04; Issue #2 