### PR TITLE
Updates to SST13 Package to include cmake, gcc

### DIFF
--- a/containers/singularity/sstpackage-13.0.0-centos8.def
+++ b/containers/singularity/sstpackage-13.0.0-centos8.def
@@ -42,7 +42,10 @@ Include: yum
                doxygen \
                automake \
                zlib-devel \
-               valgrind
+               valgrind \
+	       cmake \
+	       vim-enhanced \
+	       nano
 
     time yum clean all
     time python3 -m pip install --upgrade pip --find-links=.

--- a/containers/singularity/sstpackage-13.0.0-centos8.def
+++ b/containers/singularity/sstpackage-13.0.0-centos8.def
@@ -45,7 +45,8 @@ Include: yum
                valgrind \
 	       cmake \
 	       vim-enhanced \
-	       nano
+	       nano \
+	       gcc-toolset-11
 
     time yum clean all
     time python3 -m pip install --upgrade pip --find-links=.


### PR DESCRIPTION
This is a minor PR to update the sstpackage13 def file for Apptainer/Singularity to include some small text editors, gcc-11-toolset, and cmake 3.20. These changes add ~250-300 MB to the constructed image size, bringing it to 2.1 GB from 1.8 GB.

While not totally necessary, these additions do make it much easier to build elements like Rev, which use newer build and compiler features.